### PR TITLE
Update index.html to use an offical install link for vivaldi

### DIFF
--- a/unsupported/index.html
+++ b/unsupported/index.html
@@ -55,7 +55,7 @@
             <a href="https://www.google.com/chrome/">
                 <img src="../images/browsers/chrome.png" width="128px" style="margin-left:10px;margin-right:10px;">
             </a>
-            <a href="https://www.youtube.com/watch?v=Cz4aTSnFVvk">
+            <a href="https://vivaldi.com/download/">
                 <img src="../images/browsers/vivaldi.png" width="128px" style="margin-left:10px;margin-right:10px;">
             </a>
         </div>


### PR DESCRIPTION
The unsupported browser page currently has a link to a YouTube video by @3r1s-s on how to install Vivaldi, in my view users should be sent to the official download page, this is a better UX flow than a YouTube video.